### PR TITLE
Travis convert pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,34 +21,35 @@ matrix:
   - python: '2.7'
     env:
     - PYTHON_VERSION="2.7"
-    - NOSE_ARGS="-v --no-skip --with-cov --cov pydsd pydsd"
+    - PYTEST_ARGS="--cov=pydsd"
     - COVERALLS="true"
   - python: '3.4'
     env:
     - PYTHON_VERSION="3.4"
-    - NOSE_ARGS="-v --no-skip --with-cov --cov pydsd pydsd"
+    - PYTEST_ARGS="--cov=pydsd"
     - COVERALLS="true"
   - python: '3.5'
     env:
     - PYTHON_VERSION="3.5"
-    - NOSE_ARGS="-v --no-skip --with-cov --cov pydsd pydsd"
+    - PYTEST_ARGS="--cov=pydsd"
     - COVERALLS="true"
   - python: '3.6'
     env:
     - PYTHON_VERSION="3.6"
-    - NOSE_ARGS="-v --no-skip --with-cov --cov pydsd pydsd"
+    - PYTEST_ARGS="--cov=pydsd"
     - COVERALLS="true"
   - python: '3.6'
     env:
     - PYTHON_VERSION="3.6"
-    - NOSE_ARGS="-v --no-skip --with-cov --cov pydsd pydsd"
+    - PYTEST_ARGS="--cov=pydsd"
     - COVERALLS="true"
     - DOC_BUILD="true"
 before_install:
 - pip install pytest pytest-cov
 - pip install coveralls
 install: source continuous_integration/install.sh
-script: eval xvfb-run nosetests $NOSE_ARGS
+script: eval xvfb-run python -m pytest $PYTEST_ARGS
+#script: eval xvfb-run nosetests $NOSE_ARGS
 after_success:
 - coveralls
 - if [[ "$DOC_BUILD" == "true" ]]; then cd $TRAVIS_BUILD_DIR; source continuous_integration/build_docs.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,6 @@ matrix:
     - PYTHON_VERSION="2.7"
     - PYTEST_ARGS="--cov=pydsd"
     - COVERALLS="true"
-  - python: '3.4'
-    env:
-    - PYTHON_VERSION="3.4"
-    - PYTEST_ARGS="--cov=pydsd"
-    - COVERALLS="true"
   - python: '3.5'
     env:
     - PYTHON_VERSION="3.5"

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -21,43 +21,28 @@ wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
 chmod +x miniconda.sh
 ./miniconda.sh -b
 export PATH=/home/travis/miniconda2/bin:/home/travis/miniconda/bin:$PATH
-conda update --yes conda
-conda update --yes conda
+
+conda config --set always_yes yes
+conda config --set show_channel_urls true
+conda update -q conda
 
 # Create a testenv with the correct Python version
 conda create -n testenv --yes pip python=$PYTHON_VERSION
 source activate testenv
 
 # Install dependencies
-conda install --yes numpy scipy matplotlib netcdf4 nose sphinx numpydoc hdf4=4.2.12
-conda install --yes sphinx_rtd_theme
-pip install sphinx-gallery
-
+conda install sphinx_rtd_theme numpy scipy matplotlib netcdf4 nose sphinx numpydoc hdf4=4.2.12
+pip install sphinx-gallery nose-cov
+conda install -c conda-forge pytmatrix
 
 pip install git+https://github.com/jleinonen/pytmatrix.git
 if [[ $PYTHON_VERSION == '2.7' ]]; then
-    conda install --yes sphinx numpydoc hdf4=4.2.12
-    conda install --yes sphinx_rtd_theme
     pip install sphinxcontrib-bibtex
     pip install xmltodict
-    pip install pytmatrix
-fi
-if [[ $PYTHON_VERSION == '3.4' ]]; then
-    pip install pytmatrix
-    conda install --yes hdf4=4.2.12
-fi
-if [[ $PYTHON_VERSION == '3.5' ]]; then
-    pip install pytmatrix
-    conda install --yes hdf4=4.2.12
-fi
-if [[ $PYTHON_VERSION == '3.6' ]]; then
-    pip install pytmatrix
-    conda install --yes hdf4=4.2.12
 fi
 
 
 # install coverage modules
-pip install nose-cov
 if [[ "$COVERALLS" == "true" ]]; then
     pip install python-coveralls
 fi

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -16,11 +16,11 @@ set -e
 # a conda based install of the SciPy stack on multiple versions of Python
 # as well as use conda and binstar to install additional modules which are not
 # in the default repository.
-wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     -O miniconda.sh
 chmod +x miniconda.sh
 ./miniconda.sh -b
-export PATH=/home/travis/miniconda2/bin:/home/travis/miniconda/bin:$PATH
+export PATH=/home/travis/miniconda3/bin:$PATH
 
 conda config --set always_yes yes
 conda config --set show_channel_urls true

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -31,11 +31,10 @@ conda create -n testenv --yes pip python=$PYTHON_VERSION
 source activate testenv
 
 # Install dependencies
-conda install sphinx_rtd_theme numpy scipy matplotlib netcdf4 nose sphinx numpydoc hdf4=4.2.12
+conda install pytest pytest-cov sphinx_rtd_theme numpy scipy matplotlib netcdf4 nose sphinx numpydoc hdf4=4.2.12
 pip install sphinx-gallery nose-cov
 conda install -c conda-forge pytmatrix
 
-pip install git+https://github.com/jleinonen/pytmatrix.git
 if [[ $PYTHON_VERSION == '2.7' ]]; then
     pip install sphinxcontrib-bibtex
     pip install xmltodict


### PR DESCRIPTION
This PR covers conversion of our testing suite to Py.test. It also drops support in testing for python 3.4.  I also took some time to speed up our travis builds. 