### PR TITLE
Vdis spread fix

### DIFF
--- a/pydsd/aux_readers/ARM_Vdis_Reader.py
+++ b/pydsd/aux_readers/ARM_Vdis_Reader.py
@@ -83,7 +83,8 @@ class ArmVdisReader(object):
                 conv_factor = 1e3
             self.spread = np.array([float(width_str[0]) * conv_factor])
 
-        #  Sometimes spread is a singleton. In which case we expand it to the array as 2DVD are fixed size bins.
+        #  Sometimes spread is a singleton.
+        #  In which case we expand it to the array as 2DVD are fixed size bins.
         if len(self.spread) != Nd.shape[1]:
             self.spread = np.full(Nd.shape[1], self.spread[0])
 

--- a/pydsd/aux_readers/ARM_Vdis_Reader.py
+++ b/pydsd/aux_readers/ARM_Vdis_Reader.py
@@ -73,13 +73,13 @@ class ArmVdisReader(object):
         except KeyError:
             width_str = self.nc_dataset.bin_width.split(" ")
             units = width_str[1]
-            if(units == "mm"):
+            if units == "mm":
                 conv_factor = 1
-            elif(units == "cm"):
+            elif units == "cm":
                 conv_factor = 10
-            elif(units == "um"):
+            elif units == "um":
                 conv_factor = 1e-3
-            elif(units == "m"):
+            elif units == "m":
                 conv_factor = 1e3
             self.spread = np.array([float(width_str[0]) * conv_factor])
 

--- a/pydsd/aux_readers/ARM_Vdis_Reader.py
+++ b/pydsd/aux_readers/ARM_Vdis_Reader.py
@@ -83,6 +83,10 @@ class ArmVdisReader(object):
                 conv_factor = 1e3
             self.spread = np.array([float(width_str[0]) * conv_factor])
 
+        #  Sometimes spread is a singleton. In which case we expand it to the array as 2DVD are fixed size bins.
+        if len(self.spread) != Nd.shape[1]:
+            self.spread = np.full(Nd.shape[1], self.spread[0])
+
         # TODO: Move this to new metadata utility, and just add information from raw netcdf where appropriate
         self.bin_edges = common.var_to_dict(
             "bin_edges",

--- a/pydsd/tests/test_ARM_Vdis_Reader.py
+++ b/pydsd/tests/test_ARM_Vdis_Reader.py
@@ -55,3 +55,10 @@ class TestArmJwdReader(unittest.TestCase):
         self.assertEqual(
             self.dsd.time["data"][0], 1305590400
         )  # Basetime + first start time
+
+    def test_spread_has_same_dimension_as_bins(self):
+        """
+        This is a regression test to determine if spread is correctly being set to the same size as the bins dimension
+        of the Nd variable.
+        """
+        assert self.dsd.spread['data'].shape[0] == self.dsd.fields['Nd']['data'].shape[1]

--- a/pydsd/tests/test_ARM_Vdis_Reader.py
+++ b/pydsd/tests/test_ARM_Vdis_Reader.py
@@ -1,0 +1,57 @@
+import numpy as np
+import unittest
+
+from ..aux_readers import ARM_Vdis_Reader
+
+
+class TestArmJwdReader(unittest.TestCase):
+    """
+    Test module for the ARM_Vdis_Reader"
+    """
+
+    def setUp(self):
+        filename = "testdata/arm_vdis_b1.cdf"
+        self.dsd = ARM_Vdis_Reader.read_arm_vdis_b1(filename)
+
+    def test_can_read_sample_file(self):
+        self.assertIsNotNone(self.dsd, "File did not read in correctly, returned None")
+
+    def test_dsd_nd_exists(self):
+        self.assertIsNotNone(self.dsd.fields["Nd"], "DSD Object has no Nd field")
+
+    def test_dsd_nd_is_dict(self):
+        self.assertIsInstance(self.dsd.fields["Nd"], dict, "Nd was not a dictionary.")
+
+    def test_RR_works(self):
+        self.dsd.calculate_RR()
+        self.assertIsNotNone(
+            self.dsd.fields["rain_rate"],
+            "Rain Rate is not in fields after calculate_RR()",
+        )
+        self.assertEqual(
+            len(self.dsd.fields["rain_rate"]["data"]),
+            1440,
+            "Wrong number of time samples in rain rate",
+        )
+
+    def test_can_run_calc_dsd_params(self):
+        self.dsd.calculate_dsd_parameterization()
+        self.assertIsNotNone(
+            self.dsd.fields["D0"],
+            "The Field D0 did not exist after dsd_parameterization check",
+        )
+        self.assertEqual(
+            len(self.dsd.fields["D0"]["data"]), 1440, "Wrong number of samples in D0"
+        )
+
+    def test_time_same_length_as_Nd(self):
+        self.assertEqual(
+            len(self.dsd.time["data"]),
+            self.dsd.fields["Nd"]["data"].shape[0],
+            "Different number of samples for time and Nd",
+        )
+
+    def test_time_is_in_epoch(self):
+        self.assertEqual(
+            self.dsd.time["data"][0], 1305590400
+        )  # Basetime + first start time

--- a/pydsd/tests/test_ARM_Vdis_Reader.py
+++ b/pydsd/tests/test_ARM_Vdis_Reader.py
@@ -58,8 +58,8 @@ class TestArmJwdReader(unittest.TestCase):
 
     def test_spread_has_same_dimension_as_bins(self):
         """
-        This is a regression test to determine if spread is correctly being set to the same size as the bins dimension
-        of the Nd variable.
+        This is a regression test to determine if spread is correctly being
+        set to the same size as the bins dimension of the Nd variable.
         """
         assert (
             self.dsd.spread["data"].shape[0] == self.dsd.fields["Nd"]["data"].shape[1]

--- a/pydsd/tests/test_ARM_Vdis_Reader.py
+++ b/pydsd/tests/test_ARM_Vdis_Reader.py
@@ -61,4 +61,6 @@ class TestArmJwdReader(unittest.TestCase):
         This is a regression test to determine if spread is correctly being set to the same size as the bins dimension
         of the Nd variable.
         """
-        assert self.dsd.spread['data'].shape[0] == self.dsd.fields['Nd']['data'].shape[1]
+        assert (
+            self.dsd.spread["data"].shape[0] == self.dsd.fields["Nd"]["data"].shape[1]
+        )


### PR DESCRIPTION
This fixes an error in how spread was read in. It should be of dimension length = number of dsd bins. Instead in some of the ARM vdis files it was being read in as a singleton. This also adds a regression test for arm vdis files. 