### PR TITLE
Make canting angle configurable and clean up scattering parameters representation. 

### DIFF
--- a/pydsd/tests/test_DropSizeDistribution.py
+++ b/pydsd/tests/test_DropSizeDistribution.py
@@ -1,13 +1,32 @@
-# -*- coding: utf-8 -*-
+import pytest
+import os.path
 
-import numpy as np
-import unittest
-
+from ..aux_readers import ARM_Vdis_Reader
+from ..io.NetCDFWriter import write_netcdf
 from .. import DropSizeDistribution
 
+@pytest.fixture
+def two_dvd_open_test_file(tmpdir):
+    filename_in = "testdata/arm_vdis_b1.cdf"
+    filename_out = tmpdir + "test_2dvd.nc"
+    dsd = ARM_Vdis_Reader.read_arm_vdis_b1(filename_in)
+    return dsd
 
-class testDropSizeDistribution(unittest.TestCase):
-    """ Unit tests for DropSizeDistribution Class"""
 
-    def setUp(self):
-        pass
+class TestNetCDFWriter(object):
+    """
+    Test module for the ARM_Vdis_Reader"
+    """
+
+    @classmethod
+    def setup_method(self, test_method):
+        filename = "testdata/arm_vdis_b1.cdf"
+        self.dsd = ARM_Vdis_Reader.read_arm_vdis_b1(filename)
+
+    def test_changing_canting_angle_updates_value(self, two_dvd_open_test_file):
+        two_dvd_open_test_file.set_canting_angle(20)
+        assert two_dvd_open_test_file.scattering_params['canting_angle'] == 20
+
+    def test_canting_angle_has_default_value(self, two_dvd_open_test_file):
+        assert 'canting_angle' in two_dvd_open_test_file.scattering_params.keys()
+


### PR DESCRIPTION
Added a configurable parameter for canting angle and the set_canting_angle function to DropSizeDistribution object.

Added tests for this parameter
Moved scattering parameters to their own dictionary to make future modifications easier.