### PR TITLE
Remove 27 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ matrix:
     - PYTHON_VERSION="3.6"
     - PYTEST_ARGS="--cov=pydsd"
     - COVERALLS="true"
-  - python: '3.6'
+  - python: '3.7'
     env:
-    - PYTHON_VERSION="3.6"
+    - PYTHON_VERSION="3.7"
     - PYTEST_ARGS="--cov=pydsd"
     - COVERALLS="true"
     - DOC_BUILD="true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,6 @@ deploy:
 
 matrix:
   include:
-  - python: '2.7'
-    env:
-    - PYTHON_VERSION="2.7"
-    - PYTEST_ARGS="--cov=pydsd"
-    - COVERALLS="true"
   - python: '3.5'
     env:
     - PYTHON_VERSION="3.5"
@@ -39,13 +34,13 @@ matrix:
     - PYTEST_ARGS="--cov=pydsd"
     - COVERALLS="true"
     - DOC_BUILD="true"
-  - python: '3.7-dev'
+  - python: '3.7'
     env:
     - PYTHON_VERSION="3.7"
     - PYTEST_ARGS="--cov=pydsd"
     - COVERALLS="true"
-    allow_failures:
-      python: "3.7-dev"
+#    allow_failures:
+#      python: "3.7-dev"
 before_install:
 - pip install pytest pytest-cov
 - pip install coveralls


### PR DESCRIPTION
This PR officially removes 2.7 from the test suite. If people want to install and run on 2.7 I won't stop it, but it is no longer officially supported, nor tested. 