### PR TITLE
Fixes for issue 65 with nan elements for d0 calculation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
 #      python: "3.7-dev"
 before_install:
 - pip install pytest pytest-cov
-- pip install coverage=4.5.4 python-coveralls
+- pip install coverage==4.5.4 python-coveralls
 install: source continuous_integration/install.sh
 script: eval xvfb-run python -m pytest $PYTEST_ARGS
 #script: eval xvfb-run nosetests $NOSE_ARGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
 #      python: "3.7-dev"
 before_install:
 - pip install pytest pytest-cov
-- pip install coveralls
+- pip install coverage=4.5.4 python-coveralls
 install: source continuous_integration/install.sh
 script: eval xvfb-run python -m pytest $PYTEST_ARGS
 #script: eval xvfb-run nosetests $NOSE_ARGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,12 @@ matrix:
 #      python: "3.7-dev"
 before_install:
 - pip install pytest pytest-cov
-- pip install coverage==4.5.4 python-coveralls
+- pip install coverage==4.5.4 
+- pip install coveralls
 install: source continuous_integration/install.sh
 script: eval xvfb-run python -m pytest $PYTEST_ARGS
 #script: eval xvfb-run nosetests $NOSE_ARGS
 after_success:
-- coveralls
+# - coveralls
 - if [[ "$DOC_BUILD" == "true" ]]; then cd $TRAVIS_BUILD_DIR; source continuous_integration/build_docs.sh;
   fi

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -44,7 +44,8 @@ fi
 
 # install coverage modules
 if [[ "$COVERALLS" == "true" ]]; then
-    pip install python-coveralls
+    pip install coverage<5.0
+    pip install coveralls
 fi
 
 pip install -e .

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -44,7 +44,7 @@ fi
 
 # install coverage modules
 if [[ "$COVERALLS" == "true" ]]; then
-    pip install coverage<5.0
+    pip install 'coverage<5.0'
     pip install coveralls
 fi
 

--- a/pydsd/DropSizeDistribution.py
+++ b/pydsd/DropSizeDistribution.py
@@ -402,8 +402,12 @@ class DropSizeDistribution(object):
         if np.nansum(N) == 0:
             return 0
 
-        if np.count_nonzero(N[np.isfinite(N)]) == 1: # If there is only one nonzero/nan element, return that diameter.
-            return self.diameter['data'][np.nanargmax(N)]                # This gets around weirdness with only one valid point. 
+        if (
+            np.count_nonzero(N[np.isfinite(N)]) == 1
+        ):  # If there is only one nonzero/nan element, return that diameter.
+            return self.diameter["data"][
+                np.nanargmax(N)
+            ]  # This gets around weirdness with only one valid point.
 
         cum_W = W_const * np.nancumsum(
             [

--- a/pydsd/DropSizeDistribution.py
+++ b/pydsd/DropSizeDistribution.py
@@ -399,10 +399,13 @@ class DropSizeDistribution(object):
         rho_w = 1e-3
         W_const = rho_w * np.pi / 6.0
 
-        if np.sum(N) == 0:
+        if np.nansum(N) == 0:
             return 0
 
-        cum_W = W_const * np.cumsum(
+        if np.count_nonzero(N[np.isfinite(N)]) == 1: # If there is only one nonzero/nan element, return that diameter.
+            return self.diameter['data'][np.nanargmax(N)]                # This gets around weirdness with only one valid point. 
+
+        cum_W = W_const * np.nancumsum(
             [
                 N[k] * self.spread["data"][k] * (self.diameter["data"][k] ** 3)
                 for k in range(0, len(N))

--- a/pydsd/tests/test_DropSizeDistribution.py
+++ b/pydsd/tests/test_DropSizeDistribution.py
@@ -37,7 +37,6 @@ class TestNetCDFWriter(object):
         two_dvd_open_test_file.fields['Nd']['data'][0,1] = 5
         
         two_dvd_open_test_file.calculate_dsd_parameterization()
-        print(np.count_nonzero(np.isfinite(two_dvd_open_test_file.fields['Nd']['data'][0])))
         assert two_dvd_open_test_file.fields['D0']['data'][0] != np.nan
         assert two_dvd_open_test_file.fields['D0']['data'][0] == two_dvd_open_test_file.diameter['data'][1]
 

--- a/pydsd/tests/test_DropSizeDistribution.py
+++ b/pydsd/tests/test_DropSizeDistribution.py
@@ -33,15 +33,20 @@ class TestNetCDFWriter(object):
         assert "canting_angle" in two_dvd_open_test_file.scattering_params.keys()
 
     def test_calculating_D0_with_nan_actually_works(self, two_dvd_open_test_file):
-        two_dvd_open_test_file.fields['Nd']['data'][0,0] = np.nan # Force a nan error
-        two_dvd_open_test_file.fields['Nd']['data'][0,1] = 5
-        
+        two_dvd_open_test_file.fields["Nd"]["data"][0, 0] = np.nan  # Force a nan error
+        two_dvd_open_test_file.fields["Nd"]["data"][0, 1] = 5
+
         two_dvd_open_test_file.calculate_dsd_parameterization()
-        assert two_dvd_open_test_file.fields['D0']['data'][0] != np.nan
-        assert two_dvd_open_test_file.fields['D0']['data'][0] == two_dvd_open_test_file.diameter['data'][1]
+        assert two_dvd_open_test_file.fields["D0"]["data"][0] != np.nan
+        assert (
+            two_dvd_open_test_file.fields["D0"]["data"][0]
+            == two_dvd_open_test_file.diameter["data"][1]
+        )
 
     def test_calculating_D0_returns_correct_values(self, two_dvd_open_test_file):
-        two_dvd_open_test_file.fields['Nd']['data'][0,0] = 1 # Force a nan error
-        two_dvd_open_test_file.fields['Nd']['data'][0,1] = 2 
+        two_dvd_open_test_file.fields["Nd"]["data"][0, 0] = 1  # Force a nan error
+        two_dvd_open_test_file.fields["Nd"]["data"][0, 1] = 2
         two_dvd_open_test_file.calculate_dsd_parameterization()
-        assert np.isclose(two_dvd_open_test_file.fields['D0']['data'][0], .198, rtol=.01 ) # One percent tolerance is closer than my hand calcs.
+        assert np.isclose(
+            two_dvd_open_test_file.fields["D0"]["data"][0], .198, rtol=.01
+        )  # One percent tolerance is closer than my hand calcs.


### PR DESCRIPTION
 This adds some error catching code for cases where D0 is being calculated with arrays that contain nans, or single elements that are above zero. Also some more unit tests are added to stop regression of this in the future.