### PR TITLE
Added support for saving and loading of pre-computed scattering tables. 

### DIFF
--- a/pydsd/DropSizeDistribution.py
+++ b/pydsd/DropSizeDistribution.py
@@ -700,6 +700,9 @@ class DropSizeDistribution(object):
     def save_scattering_table(self, scattering_filename):
         ''' Save scattering table used by PyDSD to be reloaded later. Note this should only be used on disdrometers
         with the same setup for scattering (frequency, bins, max size, etc).
+        This feature is currently experimental and may be removed in the future if it turns out to not work correctly 
+        or to cause issues. 
+        
         '''
         if hasattr(self.scatterer, 'psd_integrator'):
             self.scatterer.psd_integrator.save_scatter_table(scattering_filename)

--- a/pydsd/DropSizeDistribution.py
+++ b/pydsd/DropSizeDistribution.py
@@ -173,7 +173,11 @@ class DropSizeDistribution(object):
         self.scattering_table_consistent = False
 
     def calculate_radar_parameters(
-        self, dsr_func=DSR.bc, scatter_time_range=None, max_diameter=9.0, scatter_table_filename = None
+        self,
+        dsr_func=DSR.bc,
+        scatter_time_range=None,
+        max_diameter=9.0,
+        scatter_table_filename=None,
     ):
         """ Calculates radar parameters for the Drop Size Distribution.
 
@@ -199,7 +203,7 @@ class DropSizeDistribution(object):
                 SPEED_OF_LIGHT / self.scattering_params["scattering_freq"] * 1000.0,
                 dsr_func,
                 max_diameter,
-                scatter_table_filename=scatter_table_filename
+                scatter_table_filename=scatter_table_filename,
             )
         self._setup_empty_fields()
 
@@ -258,7 +262,9 @@ class DropSizeDistribution(object):
                 param, np.ma.zeros(self.numt)
             )
 
-    def _setup_scattering(self, wavelength, dsr_func, max_diameter, scatter_table_filename=None):
+    def _setup_scattering(
+        self, wavelength, dsr_func, max_diameter, scatter_table_filename=None
+    ):
         """ Internal Function to create scattering tables.
 
         This internal function sets up the scattering table. It takes a
@@ -698,18 +704,18 @@ class DropSizeDistribution(object):
             )
 
     def save_scattering_table(self, scattering_filename):
-        ''' Save scattering table used by PyDSD to be reloaded later. Note this should only be used on disdrometers
+        """ Save scattering table used by PyDSD to be reloaded later. Note this should only be used on disdrometers
         with the same setup for scattering (frequency, bins, max size, etc).
         This feature is currently experimental and may be removed in the future if it turns out to not work correctly 
         or to cause issues. 
         
-        '''
-        if hasattr(self.scatterer, 'psd_integrator'):
+        """
+        if hasattr(self.scatterer, "psd_integrator"):
             self.scatterer.psd_integrator.save_scatter_table(scattering_filename)
         else:
-            raise AttributeError("ERROR: No scattering object has been generated. Please calculate scattering table first.")
-
-    
+            raise AttributeError(
+                "ERROR: No scattering object has been generated. Please calculate scattering table first."
+            )
 
     def _idb(self, db):
         """

--- a/pydsd/tests/test_DropSizeDistribution.py
+++ b/pydsd/tests/test_DropSizeDistribution.py
@@ -55,14 +55,14 @@ class TestNetCDFWriter(object):
     @pytest.mark.dependency()
     def test_saving_of_scatter_table(self, two_dvd_open_test_file, tmpdir):
         two_dvd_open_test_file.calculate_radar_parameters()
-        two_dvd_open_test_file.save_scattering_table(tmpdir+'/test_scatter.scatter')
-        assert os.path.isfile(tmpdir+'/test_scatter.scatter')
+        two_dvd_open_test_file.save_scattering_table(tmpdir + "/test_scatter.scatter")
+        assert os.path.isfile(tmpdir + "/test_scatter.scatter")
 
-
-    @pytest.mark.dependency(depends=['test_saving_of_scatter_table'])
+    @pytest.mark.dependency(depends=["test_saving_of_scatter_table"])
     def test_reading_of_scatter_table(self, two_dvd_open_test_file, tmpdir):
         dsd_2 = copy.copy(two_dvd_open_test_file)
         dsd_2.calculate_radar_parameters()
-        dsd_2.save_scattering_table(tmpdir+'/test_scatter.scatter')
-        two_dvd_open_test_file.calculate_radar_parameters(scatter_table_filename = tmpdir+'/test_scatter.scatter')
-
+        dsd_2.save_scattering_table(tmpdir + "/test_scatter.scatter")
+        two_dvd_open_test_file.calculate_radar_parameters(
+            scatter_table_filename=tmpdir + "/test_scatter.scatter"
+        )

--- a/pydsd/tests/test_DropSizeDistribution.py
+++ b/pydsd/tests/test_DropSizeDistribution.py
@@ -1,6 +1,7 @@
 import pytest
 import os.path
 import numpy as np
+import copy
 
 from ..aux_readers import ARM_Vdis_Reader
 from ..io.NetCDFWriter import write_netcdf
@@ -17,7 +18,7 @@ def two_dvd_open_test_file(tmpdir):
 
 class TestNetCDFWriter(object):
     """
-    Test module for the ARM_Vdis_Reader"
+    Test module for the DropSizeDistribution"
     """
 
     @classmethod
@@ -50,3 +51,18 @@ class TestNetCDFWriter(object):
         assert np.isclose(
             two_dvd_open_test_file.fields["D0"]["data"][0], .198, rtol=.01
         )  # One percent tolerance is closer than my hand calcs.
+
+    @pytest.mark.dependency()
+    def test_saving_of_scatter_table(self, two_dvd_open_test_file, tmpdir):
+        two_dvd_open_test_file.calculate_radar_parameters()
+        two_dvd_open_test_file.save_scattering_table(tmpdir+'/test_scatter.scatter')
+        assert os.path.isfile(tmpdir+'/test_scatter.scatter')
+
+
+    @pytest.mark.dependency(depends=['test_saving_of_scatter_table'])
+    def test_reading_of_scatter_table(self, two_dvd_open_test_file, tmpdir):
+        dsd_2 = copy.copy(two_dvd_open_test_file)
+        dsd_2.calculate_radar_parameters()
+        dsd_2.save_scattering_table(tmpdir+'/test_scatter.scatter')
+        two_dvd_open_test_file.calculate_radar_parameters(scatter_table_filename = tmpdir+'/test_scatter.scatter')
+


### PR DESCRIPTION
Added support for loading and saving of scattering table to speed up computation of large numbers of files. This still needs documentation, but the relevant functions are in DropSizeDistribution.save_scattering_table and an option in calculate_radar_parameters called scatter_table_filename. 

I haven't gotten to do a ton of testing on the stability of this so for now we'll consider it a bit of an experimental feature. 